### PR TITLE
Add Bakeoff Test section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ The CLI respects `.gitignore` at the repo root (if present). You can also create
 ## License
 
 MIT
+
+## Bakeoff Test
+
+This PR exists only to validate bakeoff automation.


### PR DESCRIPTION
## Summary
- Adds a Bakeoff Test section to the README

## Test plan
- This is a doc-only change for bakeoff automation validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)