### PR TITLE
docs: add bakeoff smoke test section

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,6 @@ The CLI respects `.gitignore` at the repo root (if present). You can also create
 ## License
 
 MIT
+
+## Bakeoff Test
+This PR exists only to validate bakeoff automation.


### PR DESCRIPTION
This PR exists only to validate bakeoff automation.