### PR TITLE
Add bakeoff test section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,7 @@ The CLI respects `.gitignore` at the repo root (if present). You can also create
 ## License
 
 MIT
+
+## Bakeoff Test
+
+This PR exists only to validate bakeoff automation.


### PR DESCRIPTION
## Summary
- Adds a 'Bakeoff Test' section to README.md to validate bakeoff automation

## Test plan
- Documentation-only change, no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)