### PR TITLE
Move pytest to test extra and add unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra test
 
       - name: Run tests
         run: uv run python -m pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,12 @@ requires-python = ">=3.10"
 dependencies = [
     "openai",
     "pathspec",
-    "pytest",
     "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
 ]
 
 [project.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-from cli import find_repo_root, iter_document_files
+from pathspec import PathSpec
+
+from cli import find_repo_root, is_ignored, iter_document_files, load_ignore_lines
 
 
 def test_find_repo_root_walks_up(tmp_path: Path) -> None:
@@ -35,6 +37,20 @@ def test_iter_document_files_respects_ignores(tmp_path: Path) -> None:
 
     rel_paths = {rel for rel, _ in iter_document_files(docs)}
     assert rel_paths == {"keep.txt"}
+
+
+def test_load_ignore_lines_missing_file(tmp_path: Path) -> None:
+    assert load_ignore_lines(tmp_path / "missing.ignore") == []
+
+
+def test_is_ignored_matches_rooted_path(tmp_path: Path) -> None:
+    base = tmp_path / "repo"
+    base.mkdir()
+    target = base / "secrets.txt"
+    target.write_text("nope")
+
+    spec = PathSpec.from_lines("gitwildmatch", ["secrets.txt"])
+    assert is_ignored(target, [(spec, base)]) is True
 
 
 def test_cli_help_without_api_key() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -9,17 +9,22 @@ source = { virtual = "." }
 dependencies = [
     { name = "openai" },
     { name = "pathspec" },
-    { name = "pytest" },
     { name = "python-dotenv" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "openai" },
     { name = "pathspec" },
-    { name = "pytest" },
+    { name = "pytest", marker = "extra == 'test'" },
     { name = "python-dotenv" },
 ]
+provides-extras = ["test"]
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
## Summary
- move pytest into test optional dependency group
- update CI to install test extra via uv
- add unit tests for ignore handling and CLI help

## Testing
- uv run python -m pytest -q