### PR TITLE
Move pytest to optional deps & add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra test
 
       - name: Run tests
         run: uv run python -m pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,12 @@ requires-python = ">=3.10"
 dependencies = [
     "openai",
     "pathspec",
-    "pytest",
     "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -9,17 +9,22 @@ source = { virtual = "." }
 dependencies = [
     { name = "openai" },
     { name = "pathspec" },
-    { name = "pytest" },
     { name = "python-dotenv" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "openai" },
     { name = "pathspec" },
-    { name = "pytest" },
+    { name = "pytest", marker = "extra == 'test'" },
     { name = "python-dotenv" },
 ]
+provides-extras = ["test"]
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
Closes #19. Moves pytest to [project.optional-dependencies] test, updates CI to install it, and adds pure unit tests.