### PR TITLE
Move pytest to test optional dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra test
 
       - name: Run tests
         run: uv run python -m pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,12 @@ requires-python = ">=3.10"
 dependencies = [
     "openai",
     "pathspec",
-    "pytest",
     "python-dotenv",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -9,17 +9,22 @@ source = { virtual = "." }
 dependencies = [
     { name = "openai" },
     { name = "pathspec" },
-    { name = "pytest" },
     { name = "python-dotenv" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "openai" },
     { name = "pathspec" },
-    { name = "pytest" },
+    { name = "pytest", marker = "extra == 'test'" },
     { name = "python-dotenv" },
 ]
+provides-extras = ["test"]
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
## Summary
- Removes pytest from runtime dependencies to avoid installing it for end users
- Adds `[project.optional-dependencies]` test group with pytest
- Updates CI workflow to use `uv sync --extra test`

Closes #19

## Test plan
- [x] Verified `uv sync --extra test` installs pytest
- [x] Verified `uv run python -m pytest -q` passes all tests
- [x] Verified CLI help works without `OPENAI_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)