### PR TITLE
CLI: add --version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ uv run cli.py ask "What is the main topic of these documents?"
 
 ## CLI usage
 
+Show the installed version:
+
+```bash
+uv run cli.py --version
+```
+
 Initialize with documents:
 
 ```bash

--- a/cli.py
+++ b/cli.py
@@ -2,6 +2,7 @@
 """Agentic Search - CLI tool to search documents using OpenAI vector stores."""
 
 import argparse
+import importlib.metadata
 import json
 import os
 import sys
@@ -20,6 +21,11 @@ warnings.filterwarnings("ignore", message=".*Assistants API is deprecated.*")
 from openai import OpenAI
 
 _client: OpenAI | None = None
+
+try:
+    __version__ = importlib.metadata.version("agentic-search")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.1.0"
 
 
 def get_client() -> OpenAI:
@@ -414,6 +420,11 @@ def main():
     parser = argparse.ArgumentParser(
         prog="agentic-search",
         description="Search documents using OpenAI vector stores"
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"agentic-search {__version__}",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,3 +51,23 @@ def test_cli_help_without_api_key() -> None:
 
     assert result.returncode == 0
     assert "agentic-search" in result.stdout
+
+
+def test_cli_version_without_api_key() -> None:
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+
+    result = subprocess.run(
+        [sys.executable, "cli.py", "--version"],
+        env=env,
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "agentic-search" in result.stdout
+    # Check that output contains a version number (non-empty)
+    parts = result.stdout.strip().split()
+    assert len(parts) >= 2
+    assert parts[1]  # version string is non-empty


### PR DESCRIPTION
## Summary
- Add `--version` flag to CLI that prints version and exits 0
- Works without `OPENAI_API_KEY` set (no network/API calls required)
- Version is read from package metadata via `importlib.metadata`

## What changed
- **cli.py**: Added `--version` argument using argparse's built-in `action="version"`. Version string is retrieved from package metadata at import time, with a fallback to `0.1.0` if the package isn't installed (e.g., running directly via `python cli.py`).
- **README.md**: Added `--version` usage example in the CLI usage section.
- **tests/test_cli.py**: Added `test_cli_version_without_api_key()` that runs `cli.py --version` in a subprocess with `OPENAI_API_KEY` removed, and asserts exit code 0 and that output contains program name and a non-empty version.

## How to test
```bash
# Without API key set:
unset OPENAI_API_KEY
uv run cli.py --version
# Expected output: agentic-search 0.1.0

# Run the test suite:
PYTHONPATH=. uv run pytest tests/test_cli.py -v
```

## Notes / tradeoffs
- Used `importlib.metadata` (stdlib since Python 3.8) to read version from `pyproject.toml` at runtime, avoiding duplication.
- Fallback to hardcoded `0.1.0` when package metadata is unavailable (running as script without `pip install -e .`). This keeps the version in sync with `pyproject.toml` for installed packages while still working for direct script invocation.
- No new runtime dependencies added.

Closes #27
