### PR TITLE
CLI: add --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ uv run cli.py ask "What is the main topic of these documents?"
 
 ## CLI usage
 
+Check the installed version:
+
+```bash
+uv run cli.py --version
+```
+
 Initialize with documents:
 
 ```bash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from cli import find_repo_root, iter_document_files
+from cli import find_repo_root, get_version, iter_document_files
 
 
 def test_find_repo_root_walks_up(tmp_path: Path) -> None:
@@ -51,3 +51,24 @@ def test_cli_help_without_api_key() -> None:
 
     assert result.returncode == 0
     assert "agentic-search" in result.stdout
+
+
+def test_cli_version_without_api_key() -> None:
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+
+    expected_version = get_version()
+    assert expected_version
+
+    result = subprocess.run(
+        [sys.executable, "cli.py", "--version"],
+        env=env,
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    output = result.stdout.strip()
+    assert output.startswith("agentic-search ")
+    assert output.split(" ", 1)[1] == expected_version


### PR DESCRIPTION
## Summary
- add a `--version` flag that prints a stable `agentic-search <version>` string
- read version from installed metadata with a pyproject fallback
- add a subprocess test for `--version` without `OPENAI_API_KEY`

## What changed
- added version helpers and argparse `--version` handling in `cli.py`
- documented `--version` in README usage
- added a CLI version subprocess test

## How to test
1. `PYTHONPATH=. uv run --extra test pytest`
2. `uv run cli.py --version`

## Notes / tradeoffs
- `uv run --extra test pytest` required `PYTHONPATH=.` in this environment; plain `uv run --extra test pytest` failed to import `cli`.
