### PR TITLE
Citations: extract and display sources

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-from cli import find_repo_root, get_version, iter_document_files
+from cli import (
+    build_file_id_to_name_map,
+    extract_citations,
+    find_repo_root,
+    format_sources,
+    get_version,
+    iter_document_files,
+)
 
 
 def test_find_repo_root_walks_up(tmp_path: Path) -> None:
@@ -72,3 +79,198 @@ def test_cli_version_without_api_key() -> None:
     output = result.stdout.strip()
     assert output.startswith("agentic-search ")
     assert output.split(" ", 1)[1] == expected_version
+
+
+# Mock classes to simulate OpenAI API response structure
+class MockFileCitation:
+    def __init__(self, file_id: str, quote: str = ""):
+        self.file_id = file_id
+        self.quote = quote
+
+
+class MockAnnotation:
+    def __init__(self, file_id: str, start_index: int, end_index: int, quote: str = ""):
+        self.file_citation = MockFileCitation(file_id, quote)
+        self.start_index = start_index
+        self.end_index = end_index
+
+
+class MockTextBlock:
+    def __init__(self, value: str, annotations: list | None = None):
+        self.value = value
+        self.annotations = annotations
+
+
+def test_build_file_id_to_name_map() -> None:
+    config = {
+        "file_id_map": {
+            "docs/readme.md": "file-abc123",
+            "src/main.py": "file-def456",
+        }
+    }
+    result = build_file_id_to_name_map(config)
+    assert result == {
+        "file-abc123": "docs/readme.md",
+        "file-def456": "src/main.py",
+    }
+
+
+def test_build_file_id_to_name_map_empty() -> None:
+    config = {}
+    result = build_file_id_to_name_map(config)
+    assert result == {}
+
+
+def test_extract_citations_no_annotations() -> None:
+    text_block = MockTextBlock("This is a plain answer without citations.")
+    file_id_to_name = {"file-abc": "doc.md"}
+
+    text, citations = extract_citations(text_block, file_id_to_name)
+
+    assert text == "This is a plain answer without citations."
+    assert citations == []
+
+
+def test_extract_citations_with_single_citation() -> None:
+    # Simulates: "Answer text【0†source】more text"
+    # The marker 【0†source】 spans character indices 11-21
+    text_block = MockTextBlock(
+        "Answer text【0†source】more text",
+        annotations=[
+            MockAnnotation("file-abc", 11, 21, "This is the quote"),
+        ],
+    )
+    file_id_to_name = {"file-abc": "architecture.md"}
+
+    text, citations = extract_citations(text_block, file_id_to_name)
+
+    assert text == "Answer text[1]more text"
+    assert len(citations) == 1
+    assert citations[0]["number"] == 1
+    assert citations[0]["file_name"] == "architecture.md"
+    assert citations[0]["quote"] == "This is the quote"
+
+
+def test_extract_citations_with_multiple_citations() -> None:
+    # Simulates: "First【0†source】and second【1†source】"
+    # First marker 【0†source】 spans 5-15, second 【1†source】 spans 25-35
+    text_block = MockTextBlock(
+        "First【0†source】and second【1†source】",
+        annotations=[
+            MockAnnotation("file-abc", 5, 15, "Quote one"),
+            MockAnnotation("file-def", 25, 35, "Quote two"),
+        ],
+    )
+    file_id_to_name = {
+        "file-abc": "doc1.md",
+        "file-def": "doc2.md",
+    }
+
+    text, citations = extract_citations(text_block, file_id_to_name)
+
+    assert text == "First[1]and second[2]"
+    assert len(citations) == 2
+    assert citations[0]["number"] == 1
+    assert citations[0]["file_name"] == "doc1.md"
+    assert citations[1]["number"] == 2
+    assert citations[1]["file_name"] == "doc2.md"
+
+
+def test_extract_citations_same_file_multiple_times() -> None:
+    # Same file cited twice should reuse the same citation number
+    # First marker 【0†source】 spans 5-15, second 【1†source】 spans 25-35
+    text_block = MockTextBlock(
+        "First【0†source】and second【1†source】",
+        annotations=[
+            MockAnnotation("file-abc", 5, 15, "Quote one"),
+            MockAnnotation("file-abc", 25, 35, "Quote two"),
+        ],
+    )
+    file_id_to_name = {"file-abc": "doc.md"}
+
+    text, citations = extract_citations(text_block, file_id_to_name)
+
+    assert text == "First[1]and second[1]"
+    # Only one citation entry since it's the same file
+    assert len(citations) == 1
+    assert citations[0]["number"] == 1
+
+
+def test_extract_citations_unknown_file_id() -> None:
+    text_block = MockTextBlock(
+        "Text【0†source】",
+        annotations=[
+            MockAnnotation("file-unknown", 4, 15, "Some quote"),
+        ],
+    )
+    file_id_to_name = {}  # Empty map
+
+    text, citations = extract_citations(text_block, file_id_to_name)
+
+    assert text == "Text[1]"
+    assert len(citations) == 1
+    assert citations[0]["file_name"] == "Unknown"
+
+
+def test_extract_citations_empty_quote() -> None:
+    text_block = MockTextBlock(
+        "Text【0†source】",
+        annotations=[
+            MockAnnotation("file-abc", 4, 15, ""),
+        ],
+    )
+    file_id_to_name = {"file-abc": "doc.md"}
+
+    text, citations = extract_citations(text_block, file_id_to_name)
+
+    assert len(citations) == 1
+    assert citations[0]["quote"] == ""
+
+
+def test_format_sources_empty() -> None:
+    result = format_sources([])
+    assert result == ""
+
+
+def test_format_sources_compact() -> None:
+    citations = [
+        {"number": 1, "file_name": "doc1.md", "quote": "Some quote"},
+        {"number": 2, "file_name": "doc2.py", "quote": "Another quote"},
+    ]
+
+    result = format_sources(citations, verbose=False)
+
+    assert "Sources:" in result
+    assert "[1] doc1.md" in result
+    assert "[2] doc2.py" in result
+    # Quotes should not appear in compact mode
+    assert "Some quote" not in result
+    assert "Another quote" not in result
+
+
+def test_format_sources_verbose() -> None:
+    citations = [
+        {"number": 1, "file_name": "doc1.md", "quote": "Some quote"},
+        {"number": 2, "file_name": "doc2.py", "quote": "Another quote"},
+    ]
+
+    result = format_sources(citations, verbose=True)
+
+    assert "Sources:" in result
+    assert "[1] doc1.md" in result
+    assert "[2] doc2.py" in result
+    # Quotes should appear in verbose mode
+    assert '"Some quote"' in result
+    assert '"Another quote"' in result
+
+
+def test_format_sources_verbose_empty_quote() -> None:
+    citations = [
+        {"number": 1, "file_name": "doc.md", "quote": ""},
+    ]
+
+    result = format_sources(citations, verbose=True)
+
+    assert "[1] doc.md" in result
+    # Should not have empty quote line
+    assert '""' not in result


### PR DESCRIPTION
## Summary

- Extract file citations from OpenAI Assistants API response annotations
- Replace annotation markers (e.g., `【0†source】`) with readable footnotes (`[1]`, `[2]`)
- Display a "Sources:" section showing which documents were referenced
- Add `--with-sources` flag for verbose output with quoted excerpts

## What changed

**cli.py:**
- `build_file_id_to_name_map()`: Inverts the config's `file_id_map` to look up document names from file IDs
- `extract_citations()`: Parses the `annotations` array from text blocks, extracts file citations, and replaces markers with numbered footnotes. Deduplicates citations to the same file.
- `format_sources()`: Renders the sources section in compact or verbose mode
- `cmd_ask()`: Updated to process citations and display sources after the answer
- Added `--with-sources` flag to the `ask` subparser

**tests/test_cli.py:**
- Mock classes simulating OpenAI API response structure
- Tests for `build_file_id_to_name_map()`, `extract_citations()`, and `format_sources()`
- Coverage for edge cases: no annotations, multiple citations, same file cited multiple times, unknown file ID, empty quotes

## How to test

```bash
# Run unit tests
uv sync --extra test
uv run python -m pytest -q

# Manual test (requires initialized index with documents)
uv run cli.py ask "What is the architecture?"
uv run cli.py ask --with-sources "What is the architecture?"
```

## Notes / tradeoffs

- **Citation numbering**: When the same file is cited multiple times, it reuses the same citation number. The first quote encountered is stored; subsequent quotes from the same file are not accumulated.
- **Unknown file IDs**: If a file_id in the response is not in the local config (e.g., after a sync that changed file IDs), the source displays as "Unknown" rather than failing.
- **No `chat` command**: The issue mentions both `ask` and `chat` commands, but only `ask` exists in the current codebase. Citations are implemented for `ask` only.
- **Quote display**: In verbose mode, quotes are shown with indentation and wrapped in double quotes. Very long quotes are not truncated - this could be addressed in a follow-up if needed.
