### PR TITLE
Docs: fix testing instructions for pytest extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ secrets/
 3. `sync` detects added/removed files and updates the vector store accordingly.
 4. Config is stored locally in `.agentic_search_config.json`.
 
+## Testing
+
+Install the test dependencies:
+
+```bash
+uv sync --extra test
+```
+
+Run the test suite:
+
+```bash
+uv run python -m pytest -q
+```
+
 ## License
 
 MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- add a dedicated Testing section with the required `uv sync --extra test` step
- document the recommended pytest invocation for a fresh clone

## What changed
- appended a Testing section to `README.md` with install + run commands

## How to test
1. `uv sync --extra test`
2. `uv run python -m pytest -q`

## Notes / tradeoffs
- keeps docs-only scope to match issue guidance
