### PR TITLE
Docs: fix testing instructions for pytest extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ secrets/
 3. `sync` detects added/removed files and updates the vector store accordingly.
 4. Config is stored locally in `.agentic_search_config.json`.
 
+## Testing
+
+Install dependencies including pytest:
+
+```bash
+uv sync --extra test
+```
+
+Run tests:
+
+```bash
+uv run python -m pytest -q
+```
+
 ## License
 
 MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Adds a **Testing** section to README.md documenting how to install test dependencies and run tests
- Fixes the issue where `uv run pytest` fails for a fresh clone because pytest is an optional dependency

## What changed

Added a new "Testing" section to README.md (before the License section) with:
1. Command to install test dependencies: `uv sync --extra test`
2. Command to run tests: `uv run python -m pytest -q`

## How to test

1. Clone a fresh copy of the repo
2. Follow the new Testing section instructions:
   ```bash
   uv sync --extra test
   uv run python -m pytest -q
   ```
3. Verify tests run successfully (4 tests should pass)

## Notes

- Docs-only change; no code modifications
- Kept the section minimal and consistent with existing README style
- Placed the Testing section logically after "How it works" and before "License"

Fixes #46
