### PR TITLE
Docs: fix testing instructions for pytest extra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 - `uv run cli.py ask "..."`: Query indexed documents.
 - `uv run cli.py sync ./docs`: Reconcile folder changes with the vector store.
 - `uv run cli.py cleanup --yes`: Delete remote resources and local config.
-- `uv run pytest`: Run the test suite (pytest is in the `test` optional dependency).
+- `uv run python -m pytest`: Run the test suite (pytest is in the `test` optional dependency).
 
 ## Coding Style & Naming Conventions
 - Python, 4-space indentation, standard library first, then third-party imports.
@@ -25,7 +25,7 @@
 ## Testing Guidelines
 - Framework: pytest.
 - Tests live in `tests/` and mirror public behaviors and helper utilities in `cli.py`.
-- Run all tests with `uv run pytest` before submitting changes.
+- Run all tests with `uv run python -m pytest` before submitting changes.
 
 ## Commit & Pull Request Guidelines
 - Commit messages follow a concise “Topic: summary (#NN)” pattern, e.g. `Docs: update README (#26)`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -43,7 +43,7 @@ cp .env.example .env
 ### Testing
 ```bash
 # Run all tests
-uv run pytest
+uv run python -m pytest
 ```
 
 ## Development Conventions

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ secrets/
 3. `sync` detects added/removed files and updates the vector store accordingly.
 4. Config is stored locally in `.agentic_search_config.json`.
 
+## Testing
+
+To run the test suite, you must install the optional test dependencies:
+
+```bash
+uv sync --extra test
+uv run python -m pytest -q
+```
+
 ## License
 
 MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
- Fix testing instructions in `README.md` to include installation of `test` extra.
- Update `AGENTS.md` and `GEMINI.md` to use correct test execution command.

## What changed
- Added a "Testing" section to `README.md`.
- Replaced `uv run pytest` with `uv run python -m pytest` in `AGENTS.md` and `GEMINI.md` to ensure `cli` module is found.

## How to test
1. Run `uv sync` (without extra) to simulate fresh install.
2. Run `uv run python -m pytest` -> should fail or complain about missing pytest.
3. Follow new instructions:
   ```bash
   uv sync --extra test
   uv run python -m pytest -q
   ```
   -> Tests should pass.

## Notes
- `uv run pytest` fails because `cli.py` is not in the python path by default in this project structure. `python -m pytest` adds the current directory to `sys.path`.
