### PR TITLE
DevEx: add Makefile targets for install/lint/test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: help install format format-check lint test ci
+.DEFAULT_GOAL := help
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help install format format-check lint test ci
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install dependencies (test + lint extras)
+	uv sync --extra test --extra lint
+
+format: ## Format code with ruff
+	uv run ruff format .
+
+format-check: ## Check code formatting with ruff
+	uv run ruff format --check .
+
+lint: ## Run ruff linter
+	uv run ruff check .
+
+test: ## Run tests with pytest
+	uv run python -m pytest -q
+
+ci: format-check lint test ## Run all CI checks (format-check + lint + test)


### PR DESCRIPTION
## Summary

- Add a `Makefile` with phony targets for common dev workflow tasks
- Targets use `uv run` to avoid global installs
- `make ci` matches the GitHub Actions workflow

## What Changed

Added a new `Makefile` with the following targets:

| Target | Description |
|--------|-------------|
| `help` | Show available targets with descriptions |
| `install` | Install all dependencies (`uv sync --extra test --extra lint`) |
| `format` | Format code with ruff |
| `format-check` | Check code formatting with ruff |
| `lint` | Run ruff linter |
| `test` | Run tests with pytest |
| `ci` | Run all CI checks (format-check + lint + test) |

## How to Test

```bash
# Clone and checkout branch
git fetch origin exp/opus-4-5-bakeoff-20260204-235219-claude
git checkout exp/opus-4-5-bakeoff-20260204-235219-claude

# Test targets
make help          # Shows all available targets
make install       # Installs dependencies
make ci            # Runs format-check, lint, and test
```

## Notes / Tradeoffs

- The `install` target installs both `test` and `lint` extras, providing a single command for full dev setup
- Self-documenting `make help` uses grep/awk pattern matching on `## ` comments
- No mypy included since it's not currently in the project's dependencies or CI workflow (can be added later per issue notes)

Closes #50
