### PR TITLE
DevEx: add Makefile targets for install/lint/test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+SHELL := /bin/sh
+UV ?= uv
+
+.PHONY: help install format format-check lint test ci
+
+help: ## Show available targets
+	@printf "Targets:\n"
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z_-]+:.*## / {printf "  %-14s %s\n", $1, $2}' $(MAKEFILE_LIST)
+
+install: ## Install dev dependencies (lint + test)
+	$(UV) sync --extra lint --extra test
+
+format: ## Auto-format code with ruff
+	$(UV) run ruff format .
+
+format-check: ## Check formatting with ruff
+	$(UV) run ruff format --check .
+
+lint: ## Run ruff lint checks
+	$(UV) run ruff check .
+
+test: ## Run pytest suite
+	$(UV) run python -m pytest -q
+
+ci: install format-check lint test ## Run format-check, lint, and test (CI parity)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ UV ?= uv
 
 help: ## Show available targets
 	@printf "Targets:\n"
-	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z_-]+:.*## / {printf "  %-14s %s\n", $1, $2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z_-]+:.*## / {printf "  %-14s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 install: ## Install dev dependencies (lint + test)
 	$(UV) sync --extra lint --extra test
@@ -22,4 +22,4 @@ lint: ## Run ruff lint checks
 test: ## Run pytest suite
 	$(UV) run python -m pytest -q
 
-ci: install format-check lint test ## Run format-check, lint, and test (CI parity)
+ci: install format-check lint test ## Install deps, then run format-check, lint, and test (CI parity)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ Run linter:
 uv run ruff check .
 ```
 
+## Makefile shortcuts
+
+Optional `make` targets that wrap the commands above:
+
+```bash
+make install
+make format-check
+make lint
+make test
+make ci
+```
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Optional `make` targets that wrap the commands above:
 
 ```bash
 make install
+make format
 make format-check
 make lint
 make test


### PR DESCRIPTION
## Summary
- add a top-level Makefile with install/format/lint/test/ci targets
- keep CI parity by matching the existing GitHub Actions commands

## What changed
- added `Makefile` with `install`, `format`, `format-check`, `lint`, `test`, and `ci` targets
- documented the new `make` shortcuts in `README.md`

## How to test
- `uv sync --extra test`
- `uv run python -m pytest -q`

## Notes / tradeoffs
- `make ci` installs both lint and test extras to match the workflow
