### PR TITLE
DevEx: add Makefile targets for install/lint/test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.DEFAULT_GOAL := help
 .PHONY: help install format format-check lint test ci
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@
 
 help:
 	@echo "Available targets:"
-	@echo "  make install       Install dependencies with uv (including extras)"
+	@echo "  make install       Install dependencies with uv (includes all extras for dev)"
 	@echo "  make format        Format code with ruff"
 	@echo "  make format-check  Check code formatting with ruff"
 	@echo "  make lint          Lint code with ruff"
 	@echo "  make test          Run tests with pytest"
-	@echo "  make ci            Run all checks (format-check, lint, test)"
+	@echo "  make ci            Run all checks (format-check, lint, test in order)"
 
+# Installs all extras for local development (CI installs lint/test separately)
 install:
 	uv sync --all-extras
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: help install format format-check lint test ci
+
+help:
+	@echo "Available targets:"
+	@echo "  make install       Install dependencies with uv (including extras)"
+	@echo "  make format        Format code with ruff"
+	@echo "  make format-check  Check code formatting with ruff"
+	@echo "  make lint          Lint code with ruff"
+	@echo "  make test          Run tests with pytest"
+	@echo "  make ci            Run all checks (format-check, lint, test)"
+
+install:
+	uv sync --all-extras
+
+format:
+	uv run ruff format .
+
+format-check:
+	uv run ruff format --check .
+
+lint:
+	uv run ruff check .
+
+test:
+	uv run python -m pytest -q
+
+ci: format-check lint test


### PR DESCRIPTION
## Summary
- Added `Makefile` to unify development commands.
- Wraps `uv` and `ruff` commands for consistent usage.
- Matches CI steps for local reproduction.

## What changed
- Created `Makefile` with targets: `install`, `format`, `format-check`, `lint`, `test`, `ci`, `help`.

## How to test
1. Run `make help` to see targets.
2. Run `make ci` to execute the full check suite (format check, lint, test).
3. Run `make install` to ensure dependencies sync correctly.

## Notes / tradeoffs
- Did not include `mypy` in `lint` target as it is not currently a dependency or part of the existing CI pipeline.
- Relies on `uv` being available in the environment.
